### PR TITLE
MLIBZ-1133: Unable to load redirect url when logging in with MIC

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -104,6 +104,7 @@ export class PhoneGapPopup extends EventEmitter {
     clearInterval(this.interval);
 
     if (PhoneGapDevice.isPhoneGap()) {
+      this.popup.removeEventListener('loadstart', this.eventListeners.loadStopCallback);
       this.popup.removeEventListener('loadstop', this.eventListeners.loadStopCallback);
       this.popup.removeEventListener('loaderror', this.eventListeners.loadErrorCallback);
       this.popup.removeEventListener('exit', this.eventListeners.exitCallback);

--- a/src/popup.js
+++ b/src/popup.js
@@ -87,11 +87,11 @@ export class PhoneGapPopup extends EventEmitter {
   }
 
   loadStopCallback(event) {
-    this.emit('loaded', event.url);
+    this.emit('loaded', event);
   }
 
   loadErrorCallback(event) {
-    this.emit('error', event.message);
+    this.emit('error', event);
   }
 
   exitCallback() {

--- a/src/popup.js
+++ b/src/popup.js
@@ -8,6 +8,7 @@ export class PhoneGapPopup extends EventEmitter {
 
     // Create some event listeners
     this.eventListeners = {
+      loadStartCallback: bind(this.loadStartCallback, this),
       loadStopCallback: bind(this.loadStopCallback, this),
       loadErrorCallback: bind(this.loadErrorCallback, this),
       exitCallback: bind(this.exitCallback, this)
@@ -45,6 +46,7 @@ export class PhoneGapPopup extends EventEmitter {
 
       // Listen for popup events
       if (this.popup) {
+        this.popup.addEventListener('loadstart', this.eventListeners.loadStartCallback);
         this.popup.addEventListener('loadstop', this.eventListeners.loadStopCallback);
         this.popup.addEventListener('loaderror', this.eventListeners.loadErrorCallback);
         this.popup.addEventListener('exit', this.eventListeners.exitCallback);
@@ -86,8 +88,12 @@ export class PhoneGapPopup extends EventEmitter {
     return this;
   }
 
+  loadStartCallback(event) {
+    this.emit('loadstart', event);
+  }
+
   loadStopCallback(event) {
-    this.emit('loaded', event);
+    this.emit('loadstop', event);
   }
 
   loadErrorCallback(event) {


### PR DESCRIPTION
This PR references [MLIBZ-1133](https://kinvey.atlassian.net/browse/MLIBZ-1133).

### Changes
- emit `loadstart` and `loadstop` events.
- send entire event to listeners.