### PR TITLE
MLIBZ-1492 Make Push notifications more reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "es6-promise": "^4.0.5",
     "kinvey-html5-sdk": "3.2.2",
     "kinvey-node-sdk": "3.2.2",
+    "local-storage": "^1.4.2",
     "lodash": "^4.8.2"
   },
   "peerDependencies": {

--- a/src/kinvey.js
+++ b/src/kinvey.js
@@ -4,7 +4,7 @@ import Popup from './popup';
 import Push from './push';
 import assign from 'lodash/assign';
 
-export default class Kinvey extends HTML5Kinvey {
+class Kinvey extends HTML5Kinvey {
   static init(options = {}) {
     options = assign({
       deviceClass: Device,
@@ -12,12 +12,12 @@ export default class Kinvey extends HTML5Kinvey {
     }, options);
 
     // Initialize Kinvey
-    const client = super.init(options);
-
-    // // Add Push module to Kinvey
-    this.Push = new Push({ client: client });
-
-    // Return the client
-    return client;
+    return super.init(options);
   }
 }
+
+// Add Push module
+Kinvey.Push = Push;
+
+// Export
+export default Kinvey;


### PR DESCRIPTION
### Description
This PR uses `LocalStorage` to store the device token rather then using a `CacheRequest`. The device token is name spaced to the `active user` at the time of registering the device. `Kinvey.Push` is now a singleton.

### Changes
- Use `LocalStorage` to store device token.
- Make `Kinvey.Push` a singleton.
- Update `Kinvey.Push.unregister` to unregister `phonegap-plugin-push` properly.