### PR TITLE
MLIBZ 1611: Push Event Handler Is Not "Seeing" Incoming Push After Some Time Interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "es6-promise": "^4.0.5",
     "kinvey-html5-sdk": "3.3.5",
     "kinvey-node-sdk": "3.3.5",
-    "local-storage": "^1.4.2",
     "lodash": "^4.8.2"
   },
   "devDependencies": {

--- a/test/unit/push.test.js
+++ b/test/unit/push.test.js
@@ -1,13 +1,16 @@
 import Push, { PushMock } from '../../src/push.mock';
 import { TestUser } from './mocks';
-import localStorage from 'local-storage';
 import { EventEmitter } from 'events';
 import { randomString } from 'kinvey-node-sdk/dist/utils';
+import { CacheRequest, RequestMethod } from 'kinvey-node-sdk/dist/request';
+import { NotFoundError } from 'kinvey-node-sdk/dist/errors';
 import isFunction from 'lodash/isFunction';
 import os from 'os';
+import url from 'url';
 import nock from 'nock';
 import expect from 'expect';
 import Promise from 'es6-promise';
+const APP_DATA_NAMESPACE = process.env.KINVEY_DATASTORE_NAMESPACE || 'appdata';
 const PUSH_NAMESPACE = process.env.KINVEY_PUSH_NAMESPACE || 'push';
 
 class DevicePlugin {
@@ -78,9 +81,12 @@ describe('Push', function() {
       class CustomPushNotificationPlugin extends PushNotificationPlugin {
         static init() {
           const plugin = super.init();
+
+          // Emit registration error
           setTimeout(() => {
             plugin.emit('error', deviceIdError);
-          }, 500);
+          }, 250);
+
           return plugin;
         }
       }
@@ -99,11 +105,14 @@ describe('Push', function() {
       class CustomPushNotificationPlugin extends PushNotificationPlugin {
         static init() {
           const plugin = super.init();
+
+          // Emit the registration id
           setTimeout(() => {
             plugin.emit('registration', {
               registrationId: deviceId
             });
-          }, 500);
+          }, 250);
+
           return plugin;
         }
       }
@@ -122,11 +131,11 @@ describe('Push', function() {
       return Push
         .register()
         .then((response) => {
-          expect(response).toEqual({});
+          expect(response).toEqual(deviceId);
 
-          const user = TestUser.getActiveUser(Push.client);
-          const key = `/${PUSH_NAMESPACE}/${Push.client.appKey}_${user._id}`;
-          expect(localStorage.get(key)).toEqual({ deviceId: deviceId });
+          // const user = TestUser.getActiveUser(Push.client);
+          // const key = `/${PUSH_NAMESPACE}/${Push.client.appKey}_${user._id}`;
+          // expect(localStorage.get(key)).toEqual({ deviceId: deviceId });
         });
     });
 
@@ -147,17 +156,17 @@ describe('Push', function() {
           static init() {
             const plugin = super.init();
 
-            // Send the registration id
+            // Emit the registration id
             setTimeout(() => {
               plugin.emit('registration', {
                 registrationId: deviceId
               });
-            }, 500);
 
-            // Send a notification
-            setTimeout(() => {
-              plugin.emit('notification', notification);
-            }, 750);
+              // Emmit a notification
+              setTimeout(() => {
+                plugin.emit('notification', notification);
+              }, 250);
+            }, 250);
 
             return plugin;
           }
@@ -194,9 +203,9 @@ describe('Push', function() {
         .then((response) => {
           expect(response).toEqual(null);
 
-          const user = TestUser.getActiveUser(this.client);
-          const key = `/${PUSH_NAMESPACE}/${this.client.appKey}_${user._id}`;
-          expect(localStorage.get(key)).toEqual(null);
+          // const user = TestUser.getActiveUser(this.client);
+          // const key = `/${PUSH_NAMESPACE}/${this.client.appKey}_${user._id}`;
+          // expect(localStorage.get(key)).toEqual(null);
         });
     });
 
@@ -205,11 +214,14 @@ describe('Push', function() {
       class CustomPushNotificationPlugin extends PushNotificationPlugin {
         static init() {
           const plugin = super.init();
+
+          // Emit the registration id
           setTimeout(() => {
             plugin.emit('registration', {
               registrationId: deviceId
             });
-          }, 500);
+          }, 250);
+
           return plugin;
         }
       }
@@ -239,11 +251,27 @@ describe('Push', function() {
         .register()
         .then(() => Push.unregister())
         .then((response) => {
-          expect(response).toEqual({});
+          expect(response).toEqual(null);
 
-          const user = TestUser.getActiveUser(Push.client);
-          const key = `/${PUSH_NAMESPACE}/${Push.client.appKey}_${user._id}`;
-          expect(localStorage.get(key)).toEqual(null);
+          const user = TestUser.getActiveUser(this.client);
+          const request = new CacheRequest({
+            method: RequestMethod.GET,
+            url: url.format({
+              protocol: this.client.protocol,
+              host: this.client.host,
+              pathname: `/${APP_DATA_NAMESPACE}/${this.client.appKey}/__device/${user._id}`
+            }),
+            client: this.client
+          });
+          return request.execute()
+            .catch((error) => {
+              expect(error).toBeA(NotFoundError);
+              return {};
+            })
+            .then(response => response.data)
+            .then((device) => {
+              expect(device).toEqual(null);
+            });
         });
     });
   });


### PR DESCRIPTION
### Description
This PR keeps a shared instance of the `PushNotificationPlugin`.

### Changes
- Do not set shared instance of `PushNotificationPlugin` to `null` when unregistering the device.
- Use cache storage to store device information.
- Throw error if an active user does not exist and a user id was not provided.
- Update push notification unit tests.