### PR TITLE
Support Data Encryption

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
-import { NetworkRack } from 'kinvey-js-sdk/dist/export';
+import { CacheRack, NetworkRack } from 'kinvey-js-sdk/dist/export';
 import { MobileIdentityConnect } from 'kinvey-js-sdk/dist/identity';
 import Kinvey from 'kinvey-html5-sdk';
-import { HttpMiddleware } from './middleware';
+import { CacheMiddleware, HttpMiddleware } from './middleware';
 import Popup from './popup';
 import Push from './push';
 
 // Setup racks
+CacheRack.useCacheMiddleware(new CacheMiddleware());
 NetworkRack.useHttpMiddleware(new HttpMiddleware());
 
 // Setup popup

--- a/src/middleware/cache.js
+++ b/src/middleware/cache.js
@@ -1,0 +1,8 @@
+import { CacheMiddleware as HTML5CacheMiddleware } from 'kinvey-html5-sdk/dist/middleware';
+import { Storage } from './storage';
+
+export class CacheMiddleware extends HTML5CacheMiddleware {
+  loadStorage(name, key) {
+    return new Storage(name, key);
+  }
+}

--- a/src/middleware/http.js
+++ b/src/middleware/http.js
@@ -78,7 +78,7 @@ export function deviceInformation() {
   }).join(' ');
 }
 
-export default class HttpMiddleware extends HTML5HttpMiddleware {
+export class HttpMiddleware extends HTML5HttpMiddleware {
   get deviceInformation() {
     return deviceInformation();
   }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,5 +1,2 @@
-import HttpMiddleware from './src/http';
-
-export {
-  HttpMiddleware
-};
+export * from './cache';
+export * from './http';

--- a/src/middleware/storage/index.js
+++ b/src/middleware/storage/index.js
@@ -1,0 +1,24 @@
+import { Storage as HTML5Storage } from 'kinvey-html5-sdk/dist/middleware/src/storage';
+import { WebSQLAdapter } from './websql';
+import Device from '../../device';
+
+export class Storage extends HTML5Storage {
+  constructor(name, key) {
+    super(name);
+    this.key = key;
+  }
+
+  loadAdapter() {
+    return Device.ready()
+      .then(() => {
+        return WebSQLAdapter.load(this.name, this.key);
+      })
+      .then((adapter) => {
+        if (!adapter) {
+          return super.loadAdapter();
+        }
+
+        return adapter;
+      });
+  }
+}

--- a/src/middleware/storage/websql.js
+++ b/src/middleware/storage/websql.js
@@ -1,0 +1,33 @@
+import { Promise } from 'es6-promise';
+import { WebSQLAdapter as HTML5WebSQLAdapter } from 'kinvey-html5-sdk/dist/middleware/src/storage/websql';
+import isFunction from 'lodash/isFunction';
+
+export class WebSQLAdapter extends HTML5WebSQLAdapter {
+  constructor(name = 'kinvey', key) {
+    super(name);
+    this.key = key;
+  }
+
+  openTransaction(collection, query, parameters, write = false) {
+    return new Promise((resolve, reject) => {
+      try {
+        const db = global.sqlitePlugin.openDatabase({ name: this.name, key: this.key });
+        super(collection, query, parameters, write, db)
+          .then((response) => {
+            if (db && isFunction(db.close)) {
+              db.close(() => resolve(response), reject);
+            }
+          })
+          .catch(reject);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  static load(name, key) {
+    return new Promise((resolve, reject) => {
+      window.sqlitePlugin.selfTest(() => resolve(new WebSQLAdapter(name, key)), reject);
+    });
+  }
+}

--- a/src/middleware/storage/websql.js
+++ b/src/middleware/storage/websql.js
@@ -12,7 +12,7 @@ export class WebSQLAdapter extends HTML5WebSQLAdapter {
     return new Promise((resolve, reject) => {
       try {
         const db = global.sqlitePlugin.openDatabase({ name: this.name, key: this.key });
-        super(collection, query, parameters, write, db)
+        super.openTransaction(collection, query, parameters, write, db)
           .then((response) => {
             if (db && isFunction(db.close)) {
               db.close(() => resolve(response), reject);


### PR DESCRIPTION
#### Description
Data stored with the [Cordova SQLite Plugin](https://github.com/litehelpers/Cordova-sqlite-storage) will now be encrypted if an `encryptionKey` is provided when initializing the SDK.

#### Changes
- Override `WebSQLAdapter` to use [Cordova SQLite Plugin](https://github.com/litehelpers/Cordova-sqlite-storage).
- Override `Storage` to use custom `WebSQLAdapter` mentioned above.
- Setup `CacheRack` to use custom `CacheMiddleware`.